### PR TITLE
Update CVE-2023-36664.cs

### DIFF
--- a/Moriarty/Msrc/CVE-2023-36664.cs
+++ b/Moriarty/Msrc/CVE-2023-36664.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -38,11 +38,17 @@ namespace Moriarty.Msrc
                     var foundFiles = Directory.GetFiles(drive.Name, "*", SearchOption.AllDirectories)
                         .Where(file => FilesToCheck.Any(f => file.EndsWith(f, StringComparison.OrdinalIgnoreCase)))
                         .Select(file => new FileInfo(file));
+                    
 
                     foreach (var fileInfo in foundFiles)
                     {
                         var versionInfo = FileVersionInfo.GetVersionInfo(fileInfo.FullName);
                         DebugUtility.DebugPrint($"{fileInfo.FullName} (Version: {versionInfo.FileVersion})");
+                    }
+
+                    if (foundFiles.Any())
+                    {
+                        vulnerabilities.SetAsVulnerable(Id);
                     }
                 }
                 catch (UnauthorizedAccessException)
@@ -54,8 +60,7 @@ namespace Moriarty.Msrc
                     DebugUtility.DebugPrint($"IO error occurred on {drive.Name}");
                 }
             }
-
-            vulnerabilities.SetAsVulnerable(Id);
+           
         }
     }
 }


### PR DESCRIPTION
Fixed logic error where the "true" statement for the GhostScript vuln was placed outside the loop and always returned true.
I tested on two systems manually and on no drive was any of the files present.
Still it was shown as vulnerable.