### PR TITLE
Fix print stuff

### DIFF
--- a/Moriarty/Msrc/CVE-2021-1675.cs
+++ b/Moriarty/Msrc/CVE-2021-1675.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Management;
 using Microsoft.Win32;
@@ -23,14 +23,13 @@ namespace Moriarty.Msrc
         {
             DebugUtility.DebugPrint("Performing Print Spooler vulnerability checks...");
 
-            CheckSpoolerService();
-            CheckPatchStatus();
-            CheckRegistrySettings();
+            CheckSpoolerService(vulnerabilities);
+            CheckPatchStatus(vulnerabilities);
+            CheckRegistrySettings(vulnerabilities);
 
-            vulnerabilities.SetAsVulnerable(Id);
         }
 
-        private static void CheckSpoolerService()
+        private static void CheckSpoolerService(VulnerabilityCollection vulnerabilities)
         {
             try
             {
@@ -39,6 +38,7 @@ namespace Moriarty.Msrc
                     switch (sc.Status)
                     {
                         case ServiceControllerStatus.Running:
+                            vulnerabilities.SetAsVulnerable(Id);
                             DebugUtility.DebugPrint("Print Spooler service is ENABLED and RUNNING.");
                             break;
                         case ServiceControllerStatus.Stopped:
@@ -60,7 +60,7 @@ namespace Moriarty.Msrc
             }
         }
 
-        private static void CheckPatchStatus()
+        private static void CheckPatchStatus(VulnerabilityCollection vulnerabilities)
         {
             DebugUtility.DebugPrint("Checking if system has security patches applied...");
             try
@@ -81,10 +81,12 @@ namespace Moriarty.Msrc
                     DebugUtility.DebugPrint($"Latest security patch: KB{latestPatch}.");
                     if (latestPatch >= OldestPrinterPatch)
                     {
+                        vulnerabilities.SetAsVulnerable(Id);
                         DebugUtility.DebugPrint("System is PATCHED but might still be vulnerable.");
                     }
                     else
                     {
+                        vulnerabilities.SetAsVulnerable(Id);
                         DebugUtility.DebugPrint("System is NOT PATCHED and most likely VULNERABLE!");
                     }
                 }
@@ -95,7 +97,7 @@ namespace Moriarty.Msrc
             }
         }
 
-        private static void CheckRegistrySettings()
+        private static void CheckRegistrySettings(VulnerabilityCollection vulnerabilities)
         {
             DebugUtility.DebugPrint("Checking registry settings...");
 
@@ -118,6 +120,7 @@ namespace Moriarty.Msrc
 
                 if (noWarningNoElevationOnInstall.Equals(1) || updatePromptSettings.Equals(1))
                 {
+                    vulnerabilities.SetAsVulnerable(Id);
                     DebugUtility.DebugPrint("System is likely VULNERABLE!");
                 }
                 else

--- a/Moriarty/Msrc/CVE-2023-36664.cs
+++ b/Moriarty/Msrc/CVE-2023-36664.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -38,11 +38,17 @@ namespace Moriarty.Msrc
                     var foundFiles = Directory.GetFiles(drive.Name, "*", SearchOption.AllDirectories)
                         .Where(file => FilesToCheck.Any(f => file.EndsWith(f, StringComparison.OrdinalIgnoreCase)))
                         .Select(file => new FileInfo(file));
+                    
 
                     foreach (var fileInfo in foundFiles)
                     {
                         var versionInfo = FileVersionInfo.GetVersionInfo(fileInfo.FullName);
                         DebugUtility.DebugPrint($"{fileInfo.FullName} (Version: {versionInfo.FileVersion})");
+                    }
+
+                    if (foundFiles.Any())
+                    {
+                        vulnerabilities.SetAsVulnerable(Id);
                     }
                 }
                 catch (UnauthorizedAccessException)
@@ -54,8 +60,7 @@ namespace Moriarty.Msrc
                     DebugUtility.DebugPrint($"IO error occurred on {drive.Name}");
                 }
             }
-
-            vulnerabilities.SetAsVulnerable(Id);
+           
         }
     }
 }

--- a/Moriarty/Msrc/CVE-2023-36664.cs
+++ b/Moriarty/Msrc/CVE-2023-36664.cs
@@ -38,17 +38,11 @@ namespace Moriarty.Msrc
                     var foundFiles = Directory.GetFiles(drive.Name, "*", SearchOption.AllDirectories)
                         .Where(file => FilesToCheck.Any(f => file.EndsWith(f, StringComparison.OrdinalIgnoreCase)))
                         .Select(file => new FileInfo(file));
-                    
 
                     foreach (var fileInfo in foundFiles)
                     {
                         var versionInfo = FileVersionInfo.GetVersionInfo(fileInfo.FullName);
                         DebugUtility.DebugPrint($"{fileInfo.FullName} (Version: {versionInfo.FileVersion})");
-                    }
-
-                    if (foundFiles.Any())
-                    {
-                        vulnerabilities.SetAsVulnerable(Id);
                     }
                 }
                 catch (UnauthorizedAccessException)
@@ -60,7 +54,8 @@ namespace Moriarty.Msrc
                     DebugUtility.DebugPrint($"IO error occurred on {drive.Name}");
                 }
             }
-           
+
+            vulnerabilities.SetAsVulnerable(Id);
         }
     }
 }


### PR DESCRIPTION
Update to address the output of the Printer checks.
They would always say vulnerable.
I moved the checks to each function and only added vulnerable = true if the condition would suggest that it is or might be the case.